### PR TITLE
update class names on partials to be consistent with other partials

### DIFF
--- a/src/resources/views/user/blacklist/index.blade.php
+++ b/src/resources/views/user/blacklist/index.blade.php
@@ -11,7 +11,7 @@
                 Add
             </a>
         </div>
-        <div class="card-text">
+        <div class="card-body">
             <table class="table">
                 <thead>
                     <tr>

--- a/src/resources/views/user/kickhistory/index.blade.php
+++ b/src/resources/views/user/kickhistory/index.blade.php
@@ -11,7 +11,7 @@
                 Add
             </a>
         </div>
-        <div class="card-text">
+        <div class="card-body">
             <table class="table">
                 <thead>
                     <tr>

--- a/src/resources/views/user/note/index.blade.php
+++ b/src/resources/views/user/note/index.blade.php
@@ -11,7 +11,7 @@
                 Add
             </a>
         </div>
-        <div class="card-text">
+        <div class="card-body">
             <table class="table table-striped table-hover">
                 <thead>
                     <tr>


### PR DESCRIPTION
Fixed inconsistencies in the views.

In some places the markup is:

```
<div class="card">
    ...
    <div class="card-text">
...
```

While in others it's:

```
<div class="card">
    ...
    <div class="card-body">
...
```

I think everywhere should be `.card-body` - as it already has a padding, while `.card-text` does not. It's pretty visible in the layout... Affected sections are `blacklist`, `kickhistory` and `notes`.